### PR TITLE
Backend/feat: #417 version label for core metrics

### DIFF
--- a/app/gateway/src/App/Types.hs
+++ b/app/gateway/src/App/Types.hs
@@ -23,6 +23,7 @@ import Kernel.Types.Cache
 import Kernel.Types.Common hiding (id)
 import Kernel.Types.Flow
 import Kernel.Types.Registry
+import Kernel.Utils.App (lookupDeploymentVersion)
 import Kernel.Utils.Dhall (FromDhall)
 import Kernel.Utils.IOLogging
 import qualified Kernel.Utils.Registry as Registry
@@ -61,7 +62,8 @@ data AppEnv = AppEnv
     cache :: C.Cache Text Text,
     isShuttingDown :: TMVar (),
     coreMetrics :: CoreMetricsContainer,
-    loggerEnv :: LoggerEnv
+    loggerEnv :: LoggerEnv,
+    version :: DeploymentVersion
   }
   deriving (Generic)
 
@@ -76,6 +78,7 @@ data CoreVersions = CoreVersions
 buildAppEnv :: AppCfg -> IO AppEnv
 buildAppEnv AppCfg {..} = do
   hostname <- map T.pack <$> lookupEnv "POD_NAME"
+  version <- lookupDeploymentVersion
   cache <- C.newCache Nothing
   isShuttingDown <- newEmptyTMVarIO
   coreMetrics <- registerCoreMetricsContainer

--- a/app/mock-registry/src/App/Types.hs
+++ b/app/mock-registry/src/App/Types.hs
@@ -26,11 +26,11 @@ where
 
 import EulerHS.Prelude
 import Kernel.Storage.Esqueleto.Config
-import Kernel.Tools.Metrics.CoreMetrics (CoreMetricsContainer, registerCoreMetricsContainer)
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetricsContainer, DeploymentVersion, registerCoreMetricsContainer)
 import Kernel.Types.App
 import Kernel.Types.Common
 import Kernel.Types.Flow
-import Kernel.Utils.App (getPodName)
+import Kernel.Utils.App (getPodName, lookupDeploymentVersion)
 import Kernel.Utils.Dhall (FromDhall)
 import Kernel.Utils.IOLogging
 import Kernel.Utils.Shutdown
@@ -52,7 +52,8 @@ data AppEnv = AppEnv
     isShuttingDown :: Shutdown,
     coreMetrics :: CoreMetricsContainer,
     loggerEnv :: LoggerEnv,
-    esqDBEnv :: EsqDBEnv
+    esqDBEnv :: EsqDBEnv,
+    version :: DeploymentVersion
   }
   deriving (Generic)
 
@@ -61,6 +62,7 @@ buildAppEnv AppCfg {..} = do
   isShuttingDown <- mkShutdown
   coreMetrics <- registerCoreMetricsContainer
   hostname <- getPodName
+  version <- lookupDeploymentVersion
   loggerEnv <- prepareLoggerEnv loggerConfig hostname
   esqDBEnv <- prepareEsqDBEnv esqDBCfg loggerEnv
   return AppEnv {..}

--- a/flake.lock
+++ b/flake.lock
@@ -205,14 +205,10 @@
         "beam-mysql": "beam-mysql",
         "common": "common_3",
         "flake-parts": [
-          "shared-kernel",
-          "euler-hs",
           "common",
           "flake-parts"
         ],
         "haskell-flake": [
-          "shared-kernel",
-          "euler-hs",
           "common",
           "haskell-flake"
         ],
@@ -692,7 +688,6 @@
         "common": "common_2",
         "euler-hs": "euler-hs",
         "flake-parts": [
-          "shared-kernel",
           "common",
           "flake-parts"
         ],
@@ -702,11 +697,11 @@
         "passetto-hs": "passetto-hs"
       },
       "locked": {
-        "lastModified": 1679449610,
-        "narHash": "sha256-UJ3PNc+6tfFFp2gmvQnU4XnyAFTeEUBgxF0xbXRrhSI=",
+        "lastModified": 1681123426,
+        "narHash": "sha256-ZT8Hk/alZA12MC7uSwZvmmYY3URfqiUYTCwl5qPtZ2k=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "9ed254f2dda638ef556d491cacbeec2a29fd6cae",
+        "rev": "f06badaeaeffc42772d745a5f1a36777ac4db1cd",
         "type": "github"
       },
       "original": {

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,7 +45,7 @@ packages:
 extra-deps:
   # - ../shared-kernel/lib/mobility-core
   - git: https://github.com/nammayatri/shared-kernel.git
-    commit: 1b4f9a80d495b711141fc138e8674bf4e0e05b7f
+    commit: f06badaeaeffc42772d745a5f1a36777ac4db1cd
     subdirs:
       - lib/mobility-core
   - git: https://github.com/juspay/passetto

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,12 +11,12 @@ packages:
     git: https://github.com/nammayatri/shared-kernel.git
     pantry-tree:
       size: 18496
-      sha256: 4cad69c59a698f7bca67347f0c0be6eeed13ba327ce8138488a48a5b58d1377e
-    commit: 1b4f9a80d495b711141fc138e8674bf4e0e05b7f
+      sha256: 66b00cf9a481564afe99eda5fcf2d1b6ba9c30f5a9b4ce237e0a503d7ef98276
+    commit: f06badaeaeffc42772d745a5f1a36777ac4db1cd
   original:
     subdir: lib/mobility-core
     git: https://github.com/nammayatri/shared-kernel.git
-    commit: 1b4f9a80d495b711141fc138e8674bf4e0e05b7f
+    commit: f06badaeaeffc42772d745a5f1a36777ac4db1cd
 - completed:
     subdir: core
     name: passetto-core


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Prometheus metrics being generated by the container needs to have additional version label which will be used for filtering out metrics.

version can be fetched from DEPLOYMENT_VERSION env variable.
https://github.com/nammayatri/nammayatri/issues/417->

To be merged with https://github.com/nammayatri/nammayatri/pull/441


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
<!-- 
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
