### PR TITLE
Mobility ghc927 rebased 05

### DIFF
--- a/app/gateway/beckn-gateway.cabal
+++ b/app/gateway/beckn-gateway.cabal
@@ -72,7 +72,7 @@ library
       BlockArguments
       TypeSynonymInstances
       UndecidableInstances
-  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wcompat -Widentities -Wunused-imports -Werror -fplugin=RecordDotPreprocessor -Wincomplete-uni-patterns
+  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wcompat -Widentities -Wunused-imports -Werror -fplugin=RecordDotPreprocessor -Wwarn=ambiguous-fields -Wincomplete-uni-patterns
   build-depends:
       aeson
     , base >=4.7 && <5
@@ -132,7 +132,7 @@ executable beckn-gateway-exe
       BlockArguments
       TypeSynonymInstances
       UndecidableInstances
-  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wcompat -Widentities -Wunused-imports -Werror -fplugin=RecordDotPreprocessor -threaded -rtsopts "-with-rtsopts=-N -T" -Wincomplete-uni-patterns
+  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wcompat -Widentities -Wunused-imports -Werror -fplugin=RecordDotPreprocessor -Wwarn=ambiguous-fields -threaded -rtsopts "-with-rtsopts=-N -T" -Wincomplete-uni-patterns
   build-depends:
       base >=4.7 && <5
     , beckn-gateway

--- a/app/gateway/package.yaml
+++ b/app/gateway/package.yaml
@@ -66,6 +66,7 @@ ghc-options:
   - -Wunused-imports
   - -Werror
   - -fplugin=RecordDotPreprocessor
+  - -Wwarn=ambiguous-fields
 
 library:
   source-dirs: src

--- a/app/gateway/src/App.hs
+++ b/app/gateway/src/App.hs
@@ -19,7 +19,8 @@ where
 
 import App.Server
 import App.Types
-import qualified Data.HashMap.Internal as HMap
+import qualified Data.Map.Strict as Map
+import qualified Data.HashMap.Strict as HMS
 import qualified Data.Text as T
 import EulerHS.Prelude hiding (exitSuccess)
 import EulerHS.Runtime as E
@@ -66,7 +67,7 @@ runGateway configModifier = do
             ["Proxy-Authorization", "X-Gateway-Authorization"]
             appEnv.gwId
             appCfg.authEntity.uniqueKeyId
-            & HMap.singleton signatureAuthManagerKey
+            & HMS.singleton signatureAuthManagerKey
             & createManagers
         logInfo ("Runtime created. Starting server at port " <> show port)
         return $ flowRt {R._httpClientManagers = managers}

--- a/app/gateway/src/App.hs
+++ b/app/gateway/src/App.hs
@@ -19,7 +19,6 @@ where
 
 import App.Server
 import App.Types
-import qualified Data.Map.Strict as Map
 import qualified Data.HashMap.Strict as HMS
 import qualified Data.Text as T
 import EulerHS.Prelude hiding (exitSuccess)

--- a/app/mock-registry/mock-registry.cabal
+++ b/app/mock-registry/mock-registry.cabal
@@ -48,7 +48,7 @@ library
       RecordWildCards
       OverloadedStrings
       TypeApplications
-  ghc-options: -fwrite-ide-info -hiedir=.hie -fplugin=RecordDotPreprocessor -Wall -Wcompat -Widentities -fhide-source-paths -Wno-unrecognised-pragmas -Werror
+  ghc-options: -fwrite-ide-info -hiedir=.hie -fplugin=RecordDotPreprocessor -Wwarn=ambiguous-fields -Wall -Wcompat -Widentities -fhide-source-paths -Wno-unrecognised-pragmas -Werror -Wwarn=ambiguous-fields
   build-depends:
       base >=4.7 && <5
     , euler-hs
@@ -83,7 +83,7 @@ executable mock-registry-exe
       RecordWildCards
       OverloadedStrings
       TypeApplications
-  ghc-options: -fwrite-ide-info -hiedir=.hie -fplugin=RecordDotPreprocessor -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -fwrite-ide-info -hiedir=.hie -fplugin=RecordDotPreprocessor -Wwarn=ambiguous-fields -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
     , euler-hs

--- a/app/mock-registry/package.yaml
+++ b/app/mock-registry/package.yaml
@@ -46,6 +46,7 @@ ghc-options:
   - -fwrite-ide-info
   - -hiedir=.hie
   - -fplugin=RecordDotPreprocessor
+  - -Wwarn=ambiguous-fields
 
 library:
   source-dirs: src
@@ -56,6 +57,7 @@ library:
     - -fhide-source-paths
     - -Wno-unrecognised-pragmas
     - -Werror
+    - -Wwarn=ambiguous-fields
   dependencies:
     - mobility-core
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,36 +1,85 @@
 {
   "nodes": {
     "beam": {
-      "flake": false,
+      "inputs": {
+        "flake-parts": "flake-parts_7",
+        "haskell-flake": [
+          "shared-kernel",
+          "euler-hs",
+          "sequelize",
+          "beam-mysql",
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "shared-kernel",
+          "euler-hs",
+          "sequelize",
+          "beam-mysql",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1676828369,
-        "narHash": "sha256-qCTCvYbrVJBr6dAWsvjt9cFiMiUDoh9U6L8Ykl3xtmU=",
-        "owner": "srid",
+        "lastModified": 1693307537,
+        "narHash": "sha256-BIq3ZjZQWQ0w3zWA19zGBggiVVfnOzR5d4b7De0oVZY=",
+        "owner": "arjunkathuria",
         "repo": "beam",
-        "rev": "d7031dcffafcab55850c9b3fd2561d3e279f1965",
+        "rev": "06bcc50997fdcfb87125bed252e888e5dd1e6d9c",
         "type": "github"
       },
       "original": {
-        "owner": "srid",
-        "ref": "ghc810",
+        "owner": "arjunkathuria",
+        "ref": "GHC-927-Upgrade",
         "repo": "beam",
         "type": "github"
       }
     },
     "beam-mysql": {
+      "inputs": {
+        "beam": "beam",
+        "bytestring-lexing": "bytestring-lexing",
+        "flake-parts": "flake-parts_8",
+        "haskell-flake": [
+          "shared-kernel",
+          "euler-hs",
+          "sequelize",
+          "haskell-flake"
+        ],
+        "mysql-haskell": "mysql-haskell",
+        "nixpkgs": [
+          "shared-kernel",
+          "euler-hs",
+          "sequelize",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1693308989,
+        "narHash": "sha256-3qyg/Uj3A+MTS494VH2lTBtOz9uptgm+V1M1bPFxTX0=",
+        "owner": "arjunkathuria",
+        "repo": "beam-mysql",
+        "rev": "2ef13d8ecdcd0959b8604b3106b2013baf2ad272",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arjunkathuria",
+        "ref": "GHC-927",
+        "repo": "beam-mysql",
+        "type": "github"
+      }
+    },
+    "bytestring-lexing": {
       "flake": false,
       "locked": {
-        "lastModified": 1675165348,
-        "narHash": "sha256-sFOtfvAeFwIaMpMK8vD5usE71/jTHwDCdbf++h4jOqQ=",
+        "lastModified": 1596188445,
+        "narHash": "sha256-n/5kFb5msE8NPQZf6bsm8MQh0RGDoOx6EJXoji6FPMs=",
         "owner": "juspay",
-        "repo": "beam-mysql",
-        "rev": "b4dbc91276f6a8b5356633492f89bdac34ccd9a1",
+        "repo": "bytestring-lexing",
+        "rev": "0a46db1139011736687cb50bbd3877d223bcb737",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
-        "repo": "beam-mysql",
-        "rev": "b4dbc91276f6a8b5356633492f89bdac34ccd9a1",
+        "repo": "bytestring-lexing",
         "type": "github"
       }
     },
@@ -160,17 +209,16 @@
     "cereal": {
       "flake": false,
       "locked": {
-        "lastModified": 1668616659,
-        "narHash": "sha256-FkwxTJzY4A2CaGnQ+YBdEKZr+apEBK8Awcxrfp4uIvE=",
+        "lastModified": 1696234101,
+        "narHash": "sha256-dDUIny/9kZ0Bx/r/IPa9XRDcNT10XweR1uHqKx1CbAk=",
         "owner": "juspay",
         "repo": "cereal",
-        "rev": "213f145ccbd99e630ee832d2f5b22894c810d3cc",
+        "rev": "ee7fc69f499e86b8274906ba183b60f4f08457a6",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
         "repo": "cereal",
-        "rev": "213f145ccbd99e630ee832d2f5b22894c810d3cc",
         "type": "github"
       }
     },
@@ -182,11 +230,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685470264,
-        "narHash": "sha256-WIrCW9tisY+S4uto3YhToSZPcxLtE82hOep9c5thHXU=",
+        "lastModified": 1699959073,
+        "narHash": "sha256-0Ovbd1CzgI4tSCTBe6z/7p8DpbajKyFlyS39hu4xpNY=",
         "owner": "nammayatri",
         "repo": "clickhouse-haskell",
-        "rev": "298bbaa9990ad34dd6836414a0d3e64387578774",
+        "rev": "5314118b2635724b87f7993da9dc8446602bcd65",
         "type": "github"
       },
       "original": {
@@ -211,11 +259,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1687365764,
-        "narHash": "sha256-T67Dr9TvZYfXEOuFPfdDnNKTc1Kqy6xyhFjXEXHu1Dc=",
+        "lastModified": 1700137322,
+        "narHash": "sha256-QHWoOy48nH/V3uqPhIjQnCWqiIQVWuDOQlAe1KSjR84=",
         "owner": "nammayatri",
         "repo": "common",
-        "rev": "5f16f3ebf64a4523eb8c1b20dadcb65cef5146ab",
+        "rev": "d5e3ed3f389cc5f5d3272912aa5207afba9436a0",
         "type": "github"
       },
       "original": {
@@ -240,11 +288,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1685470074,
-        "narHash": "sha256-0vdewKY4Vmx476Qg5qd2voyuL7ZssqOUlQeNJCuvs3Q=",
+        "lastModified": 1700137322,
+        "narHash": "sha256-QHWoOy48nH/V3uqPhIjQnCWqiIQVWuDOQlAe1KSjR84=",
         "owner": "nammayatri",
         "repo": "common",
-        "rev": "9b0393630068e688795bedd46c49df1a0bbc7c0a",
+        "rev": "d5e3ed3f389cc5f5d3272912aa5207afba9436a0",
         "type": "github"
       },
       "original": {
@@ -269,11 +317,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1687365764,
-        "narHash": "sha256-T67Dr9TvZYfXEOuFPfdDnNKTc1Kqy6xyhFjXEXHu1Dc=",
+        "lastModified": 1699950488,
+        "narHash": "sha256-llyrSKHNFL1FptFykCelRjitl3x0b4JsSkQQyCKVZhU=",
         "owner": "nammayatri",
         "repo": "common",
-        "rev": "5f16f3ebf64a4523eb8c1b20dadcb65cef5146ab",
+        "rev": "0ae95ce0df4a0c6be221fdbd946f35e54e97ccf5",
         "type": "github"
       },
       "original": {
@@ -417,7 +465,6 @@
         "haskell-flake": [
           "shared-kernel",
           "euler-hs",
-          "common",
           "haskell-flake"
         ],
         "nixpkgs": "nixpkgs_16",
@@ -440,8 +487,6 @@
     },
     "euler-hs": {
       "inputs": {
-        "beam": "beam",
-        "beam-mysql": "beam-mysql",
         "cereal": "cereal",
         "common": "common_3",
         "euler-events-hs": "euler-events-hs",
@@ -453,27 +498,24 @@
         ],
         "haskell-flake": [
           "shared-kernel",
-          "euler-hs",
-          "common",
           "haskell-flake"
         ],
         "hedis": "hedis",
         "juspay-extra": "juspay-extra",
-        "mysql-haskell": "mysql-haskell",
         "nixpkgs": [
           "shared-kernel",
-          "euler-hs",
-          "common",
           "nixpkgs"
         ],
-        "sequelize": "sequelize"
+        "sequelize": "sequelize",
+        "servant-mock": "servant-mock",
+        "tinylog": "tinylog"
       },
       "locked": {
-        "lastModified": 1690897493,
-        "narHash": "sha256-50FaBXBH5qc9LHp4en4lE/scjs2wUsl3wDk3ioJBVBY=",
+        "lastModified": 1699954198,
+        "narHash": "sha256-o7t0pQtXBo+pEXk7lJ7J2Z07HEWFvlTwy7ZPoPn4Ptw=",
         "owner": "juspay",
         "repo": "euler-hs",
-        "rev": "3fb3536479b4525384d0aeac93a1ffe5c5bf47f8",
+        "rev": "9492f18e5a36e163c3c55965254fe97f4524f7ac",
         "type": "github"
       },
       "original": {
@@ -597,6 +639,24 @@
         "type": "github"
       }
     },
+    "flake-parts_10": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_10"
+      },
+      "locked": {
+        "lastModified": 1683560683,
+        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_2"
@@ -692,11 +752,47 @@
         "nixpkgs-lib": "nixpkgs-lib_7"
       },
       "locked": {
-        "lastModified": 1683560683,
-        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_8": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_8"
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_9": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_9"
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
         "type": "github"
       },
       "original": {
@@ -1105,7 +1201,6 @@
         "haskell-flake": [
           "shared-kernel",
           "euler-hs",
-          "common",
           "haskell-flake"
         ],
         "nixpkgs": "nixpkgs_18"
@@ -1218,19 +1313,36 @@
       }
     },
     "mysql-haskell": {
-      "flake": false,
+      "inputs": {
+        "flake-parts": "flake-parts_9",
+        "haskell-flake": [
+          "shared-kernel",
+          "euler-hs",
+          "sequelize",
+          "beam-mysql",
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "shared-kernel",
+          "euler-hs",
+          "sequelize",
+          "beam-mysql",
+          "nixpkgs"
+        ],
+        "word24": "word24"
+      },
       "locked": {
-        "lastModified": 1594736429,
-        "narHash": "sha256-mxIaWkfyrF0FhEK2WLhyPiIiGjKlG2kUn78E+GDAGAw=",
-        "owner": "juspay",
+        "lastModified": 1692868544,
+        "narHash": "sha256-UY9HRnqWXv5Ud6pfBa/fPNwjauDYpgzJoLcQb4NuH7I=",
+        "owner": "arjunkathuria",
         "repo": "mysql-haskell",
-        "rev": "788022d65538db422b02ecc0be138b862d2e5cee",
+        "rev": "2f4861667d19e84474700f32922c97af94f5dfc4",
         "type": "github"
       },
       "original": {
-        "owner": "juspay",
+        "owner": "arjunkathuria",
+        "ref": "GHC-927",
         "repo": "mysql-haskell",
-        "rev": "788022d65538db422b02ecc0be138b862d2e5cee",
         "type": "github"
       }
     },
@@ -1445,6 +1557,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_10": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib_2": {
       "locked": {
         "dir": "lib",
@@ -1538,11 +1668,47 @@
     "nixpkgs-lib_7": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1682879489,
-        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_8": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_9": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
         "type": "github"
       },
       "original": {
@@ -1747,11 +1913,11 @@
     },
     "nixpkgs_13": {
       "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "lastModified": 1696261572,
+        "narHash": "sha256-s8TtSYJ1LBpuITXjbPLUPyxzAKw35LhETcajJjCS5f0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "rev": "0c7ffbc66e6d78c50c38e717ec91a2a14e0622fb",
         "type": "github"
       },
       "original": {
@@ -1875,11 +2041,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "lastModified": 1696261572,
+        "narHash": "sha256-s8TtSYJ1LBpuITXjbPLUPyxzAKw35LhETcajJjCS5f0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "rev": "0c7ffbc66e6d78c50c38e717ec91a2a14e0622fb",
         "type": "github"
       },
       "original": {
@@ -1955,11 +2121,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "lastModified": 1696261572,
+        "narHash": "sha256-s8TtSYJ1LBpuITXjbPLUPyxzAKw35LhETcajJjCS5f0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "rev": "0c7ffbc66e6d78c50c38e717ec91a2a14e0622fb",
         "type": "github"
       },
       "original": {
@@ -2178,11 +2344,11 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1680797953,
-        "narHash": "sha256-lFYbfId1IX6jh/wUf+gt3LyvE9HblS4hcBQcougSzX0=",
+        "lastModified": 1687298948,
+        "narHash": "sha256-7Lu4/odCkkwrzR8Mo+3D+URv4oLap8WWLESzi/75eb0=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "aee1b8d126a5efe5945513eb2fb343f3d68dca4b",
+        "rev": "5bdb90b85642901cf9a5dccfe8c907091c261604",
         "type": "github"
       },
       "original": {
@@ -2193,11 +2359,11 @@
     },
     "process-compose-flake_2": {
       "locked": {
-        "lastModified": 1680797953,
-        "narHash": "sha256-lFYbfId1IX6jh/wUf+gt3LyvE9HblS4hcBQcougSzX0=",
+        "lastModified": 1687298948,
+        "narHash": "sha256-7Lu4/odCkkwrzR8Mo+3D+URv4oLap8WWLESzi/75eb0=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "aee1b8d126a5efe5945513eb2fb343f3d68dca4b",
+        "rev": "5bdb90b85642901cf9a5dccfe8c907091c261604",
         "type": "github"
       },
       "original": {
@@ -2209,10 +2375,10 @@
     "process-compose-flake_3": {
       "locked": {
         "lastModified": 1687298948,
-        "narHash": "sha256-lFYbfId1IX6jh/wUf+gt3LyvE9HblS4hcBQcougSzX0=",
+        "narHash": "sha256-7Lu4/odCkkwrzR8Mo+3D+URv4oLap8WWLESzi/75eb0=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "aee1b8d126a5efe5945513eb2fb343f3d68dca4b",
+        "rev": "5bdb90b85642901cf9a5dccfe8c907091c261604",
         "type": "github"
       },
       "original": {
@@ -2249,7 +2415,7 @@
     },
     "prometheus-haskell_2": {
       "inputs": {
-        "flake-parts": "flake-parts_7",
+        "flake-parts": "flake-parts_10",
         "haskell-flake": [
           "shared-kernel",
           "common",
@@ -2275,23 +2441,65 @@
     "root": {
       "inputs": {
         "common": "common",
+        "haskell-flake": [
+          "common",
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "common",
+          "nixpkgs"
+        ],
         "shared-kernel": "shared-kernel"
       }
     },
     "sequelize": {
-      "flake": false,
+      "inputs": {
+        "beam-mysql": "beam-mysql",
+        "flake-parts": [
+          "shared-kernel",
+          "euler-hs",
+          "flake-parts"
+        ],
+        "haskell-flake": [
+          "shared-kernel",
+          "euler-hs",
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "shared-kernel",
+          "euler-hs",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1688647938,
-        "narHash": "sha256-F7nixhDpXNRrpgxRH3xtnN+FkB2HS44VMrnoq1VfBnI=",
+        "lastModified": 1696055637,
+        "narHash": "sha256-RVlpKevWjt9pB9Ia61+ILFcbjB8omiRA6zehmPb6FHg=",
         "owner": "juspay",
         "repo": "haskell-sequelize",
-        "rev": "dc01b0f9e6ba5a51dd8f9d0744a549dc9c0ba244",
+        "rev": "991064c0b9b5f5cf691b19d53ac6b0c9109a2dff",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
+        "ref": "beckn-compatible",
         "repo": "haskell-sequelize",
-        "rev": "dc01b0f9e6ba5a51dd8f9d0744a549dc9c0ba244",
+        "type": "github"
+      }
+    },
+    "servant-mock": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672315259,
+        "narHash": "sha256-J7Lsa3zI1Z05Gtf5m1x4yRE5vRnuhZLWeUShtrhsPbk=",
+        "owner": "arjunkathuria",
+        "repo": "servant-mock",
+        "rev": "17e90cb831820a30b3215d4f164cf8268607891e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arjunkathuria",
+        "repo": "servant-mock",
+        "rev": "17e90cb831820a30b3215d4f164cf8268607891e",
         "type": "github"
       }
     },
@@ -2300,15 +2508,25 @@
         "clickhouse-haskell": "clickhouse-haskell",
         "common": "common_2",
         "euler-hs": "euler-hs",
+        "haskell-flake": [
+          "shared-kernel",
+          "common",
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "shared-kernel",
+          "common",
+          "nixpkgs"
+        ],
         "passetto-hs": "passetto-hs",
         "prometheus-haskell": "prometheus-haskell_2"
       },
       "locked": {
-        "lastModified": 1692257273,
-        "narHash": "sha256-bkingGL6/dZnStayH8c3zqXVEyn99+8vc4v9E7+lTp4=",
+        "lastModified": 1700464217,
+        "narHash": "sha256-60v79mntoT/FXBgbl8Z39yH7xtPC2MOIcMGz+kJNVac=",
         "owner": "nammayatri",
         "repo": "shared-kernel",
-        "rev": "0a2bddf14485293b9e840e1b9eca58a7b9461aa4",
+        "rev": "d5bef3a22afff708fdf06cc063ef73c9be721be1",
         "type": "github"
       },
       "original": {
@@ -2362,6 +2580,22 @@
         "type": "github"
       }
     },
+    "tinylog": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669960992,
+        "narHash": "sha256-o0WEbygbbfIYPonyY6ui1HcbaJcFdngjBhnjWbe65zs=",
+        "rev": "08d3b6066cd2f883e183b7cd01809d1711092d33",
+        "revCount": 78,
+        "type": "git",
+        "url": "https://gitlab.com/arjunkathuria/tinylog.git"
+      },
+      "original": {
+        "rev": "08d3b6066cd2f883e183b7cd01809d1711092d33",
+        "type": "git",
+        "url": "https://gitlab.com/arjunkathuria/tinylog.git"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_5"
@@ -2413,6 +2647,22 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "word24": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647587255,
+        "narHash": "sha256-S37S10sJ45BulvpqJzlhX/J4hY7cW5jLM9nP4xAftac=",
+        "owner": "winterland1989",
+        "repo": "word24",
+        "rev": "445f791e35ddc8098f05879dbcd07c41b115cb39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "winterland1989",
+        "repo": "word24",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
   inputs = {
     common.url = "github:nammayatri/common";
+    nixpkgs.follows = "common/nixpkgs";
+    haskell-flake.follows = "common/haskell-flake";
 
     shared-kernel.url = "github:nammayatri/shared-kernel";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -24,10 +24,8 @@
           autoWire = [ "packages" "checks" "apps" ];
         };
 
-        process-compose.configs.run.processes = {
-          beckn-gateway.command = lib.getExe self'.packages.beckn-gateway;
-          mock-registry.command = lib.getExe self'.packages.mock-registry;
-        };
+        # FIX ME: confirm what the "process-compose" field needs to be
+        process-compose = { };
 
         packages.default = self'.packages.beckn-gateway;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [x] Dependency updates

## Description
This PR enables the beckn-gateway repository to build with GHC 9.2.7 and all its upgraded package-set and dependencies that come with the upgraded GHC927 package set, updated and rebased to work with the newest commit.

This is part of the larger efforts to upgrade and bring the entire nammayatri ecosystem on GHC 9.2.

To give a brief summary of changes, including but not limited to :-

- Modifies the codebase to accomodate the updated juspay and internal dependencies, which were in-turn patched to be able to build with GHC 9.2.7
- Handles and fixes all breaking changes across major version of repositories like Aeson v2+, Text 2+ etc.
- Updates the nix setup accordingly.
- t also upgrades the project tooling like Haskell-Language-Server (HLS) etc.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables

modifies the `flake.nix` and `flake.lock` for dependency upgrades

## Motivation and Context
GHC 9.2 upgrade. A full document of motivations and benefits is being prepared and will be shared internally across teams.

## How did you test it?

- [x] The project builds on my local
- [x] Passes all pre-commit checks

local rideflow testing was also done.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
