### PR TITLE
Solve process-compose related "FIX ME" in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,8 +24,14 @@
           autoWire = [ "packages" "checks" "apps" ];
         };
 
-        # FIX ME: confirm what the "process-compose" field needs to be
-        process-compose = { };
+        process-compose."run" = {
+          settings = {
+            processes = {
+              beckn-gateway.command = lib.getExe self'.packages.beckn-gateway;
+              mock-registry.command = lib.getExe self'.packages.mock-registry;
+            };
+          };
+        };
 
         packages.default = self'.packages.beckn-gateway;
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
Updates a process-compose related "FIX ME" in flake.nix file which was marked as such in a previous iteration

Should now be on parity with what it used to be before.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables
<!--
Provide links to the files with corresponding changes.

You can find config files in `dhall-configs`
-->


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
During the update to GHC 9.2.7, process-compose-flake version got implicitly upgraded as-well.
The newer process-compose-flake version was incompatible with the older syntax present in the repo for it and thus was marked as a fix-me, to be looked at later.
Finally got around to solving the previous "FIX ME".

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Built on local. DevShell builds, cabal project builds.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
